### PR TITLE
Include graceful shutdown

### DIFF
--- a/src/integrations/typescript/src/index.ts
+++ b/src/integrations/typescript/src/index.ts
@@ -2,3 +2,7 @@ import server from './server';
 
 server.listen(server.get('port'));
 console.log('Server is running on port', server.get('port'));
+
+process.on('SIGINT', function() {
+    process.exit();
+});


### PR DESCRIPTION
The pozoljs applications persists in the background if you use it with pm2. Include this code into the index to avoid this problem, according to the pm2 documentation:
https://pm2.keymetrics.io/docs/usage/signals-clean-restart/